### PR TITLE
Add CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,33 @@
+name: CD
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push server image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./server
+          file: ./server/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/server:latest
+      - name: Build and push client image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/client:latest

--- a/README.md
+++ b/README.md
@@ -32,3 +32,16 @@ A Docker Compose file is provided to run MongoDB, the Go server, and the client 
 ```bash
 docker-compose up --build
 ```
+
+## Continuous Deployment
+
+The repository includes a `CD` workflow that builds Docker images for the server and
+client whenever the `CI` workflow succeeds on `main`. Images are published to the
+GitHub Container Registry under your repository. You can pull and run them with:
+
+```bash
+docker pull ghcr.io/<owner>/<repo>/server:latest
+docker pull ghcr.io/<owner>/<repo>/client:latest
+```
+
+Adjust `<owner>/<repo>` to match your GitHub repository name.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds and pushes Docker images
- document the CD workflow in the README

## Testing
- `go test ./...` *(no tests to run)*
- `npm test` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_686987a83674832eae31d4e9b19e82f4